### PR TITLE
Fix for bugfix command

### DIFF
--- a/git-flow-completion.bash
+++ b/git-flow-completion.bash
@@ -8,8 +8,8 @@
 # The contained completion routines provide support for completing:
 #
 #  * git-flow init and version
-#  * feature, hotfix and release branches
-#  * remote feature, hotfix and release branch names
+#  * feature, bugfix, hotfix and release branches
+#  * remote feature, bugfix, hotfix and release branch names
 #
 #
 # Installation
@@ -216,7 +216,7 @@ __git_flow_bugfix ()
         return
         ;;
     checkout)
-        __gitcomp_nl "$(__git_flow_list_local_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_local_branches 'bugfix')"
         return
         ;;
     delete)
@@ -229,7 +229,7 @@ __git_flow_bugfix ()
             return
             ;;
         esac
-        __gitcomp_nl "$(__git_flow_list_local_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_local_branches 'bugfix')"
         return
         ;;
     finish)
@@ -249,11 +249,11 @@ __git_flow_bugfix ()
             return
             ;;
         esac
-        __gitcomp_nl "$(__git_flow_list_local_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_local_branches 'bugfix')"
         return
         ;;
     diff)
-        __gitcomp_nl "$(__git_flow_list_local_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_local_branches 'bugfix')"
         return
         ;;
     rebase)
@@ -266,15 +266,15 @@ __git_flow_bugfix ()
             return
             ;;
         esac
-        __gitcomp_nl "$(__git_flow_list_local_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_local_branches 'bugfix')"
         return
         ;;
     publish)
-        __gitcomp_nl "$(__git_flow_list_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_branches 'bugfix')"
         return
         ;;
     track)
-        __gitcomp_nl "$(__git_flow_list_branches 'feature')"
+        __gitcomp_nl "$(__git_flow_list_branches 'bugfix')"
         return
         ;;
     *)
@@ -517,7 +517,7 @@ __git_flow_config ()
         esac
         __gitcomp "
             master develop
-            feature hotfix release support
+            feature bugfix hotfix release support
             versiontagprefix
             "
         return
@@ -543,7 +543,7 @@ __git_flow_config ()
 __git_flow_prefix ()
 {
     case "$1" in
-    feature|release|hotfix|support)
+    feature|bugfix|release|hotfix|support)
         git config "gitflow.prefix.$1" 2> /dev/null || echo "$1/"
         return
         ;;


### PR DESCRIPTION
modified:   git-flow-completion.bash

Auto-completion for the bugfix command used the list of features instead
of bugfixes. Now the list of bugfixes is used.