### PR TITLE
Preserve the existing user_commands in the git completion system

### DIFF
--- a/git-flow-completion.zsh
+++ b/git-flow-completion.zsh
@@ -545,4 +545,6 @@ __git_command_successful () {
     return 0
 }
 
-zstyle ':completion:*:*:git:*' user-commands flow:'provide high-level repository operations'
+zstyle -g existing_user_commands ':completion:*:*:git:*' user-commands
+
+zstyle ':completion:*:*:git:*' user-commands $existing_user_commands flow:'provide high-level repository operations'


### PR DESCRIPTION
Hi,

this PR addresses #13. Instead of completely overwriting the user-commands variable, we retrieve its value first and we add the additional completion mechanisms later. This is needed when the user has several packages that try to use this completion extension mechanism. With the current code, the last loaded package overwrites the rest.

Regards